### PR TITLE
Proposal for adding Dependent Pairs (Σ-types) to LaTTe

### DIFF
--- a/test/latte_kernel/typing_test.cljc
+++ b/test/latte_kernel/typing_test.cljc
@@ -45,6 +45,9 @@
   (is (= (type-of-term defenv/empty-env [] '(Π [x ✳] x))
          '[:ok ✳ (Π [x ✳] x)]))
 
+  (is (= (type-of-term defenv/empty-env [] '(Σ [x ✳] x))
+         '[:ok ✳ (Σ [x ✳] x)]))
+
   (is (= (type-of-term defenv/empty-env [] '(Π [x ✳] ✳))
          '[:ok □ (Π [x ✳] ✳)]))
 
@@ -59,6 +62,29 @@
                 :term □,
                 :from {:msg "Kind has not type", :term □}}
            nil])))
+
+(deftest test-type-of-pair-and-projections
+  (is (= (type-of-term defenv/empty-env '[[A ✳] [B ✳] [u A] [v B]]
+                       '(pair u v))
+         '[:ok (Σ [x A] B) (pair u v)]))
+
+  (is (= (type-of-term defenv/empty-env '[[A ✳] [B ✳] [p (Σ [t A] B)]]
+                       '(pr1 p))
+         '[:ok A p]))
+
+  (is (= (type-of-term defenv/empty-env '[[A ✳] [B ✳] [p (Σ [t A] B)]]
+                       '(pr2 p))
+         '[:ok B p]))
+
+  ;; TODO: add tests for real dependent pairs:
+  ;; why do these throw with No such definition '{:term (P t), :def-name P}' ?
+  #_#_
+  (is (= (type-of-term defenv/empty-env '[[T ✳] [P (==> T ✳)] [p (Σ [t T] (P t))]]
+                       '(pr2 p))
+         '[:ok (P (pr1 p)) (pr2 p)]))
+  (is (= (type-of-term defenv/empty-env '[[T ✳] [P (==> T ✳)] [x T] [y (P x)]]
+                       '(pair x y))
+         '[:ok (Σ [t T] (P t)) nil])))
 
 (deftest test-type-of-abs
   (is (= (type-of-term defenv/empty-env '[[bool ✳] [t bool] [y bool]]


### PR DESCRIPTION
Hello @fredokun 👋 .

First of all thank you very much for suggesting to read Nederpelt's book on type theory and formal proof, it's great to get the overall picture on the lambda cube and the formalisation of maths via types.

I've been reading some papers around formalising mathematics in Coq (e.g. [[1]](https://hal.inria.fr/inria-00368403v1/document), [[2]](https://perso.crans.org/cohen/papers/quotients.pdf) and the introduction to [[HoTT]](https://homotopytypetheory.org/book/)), to have some inspiration for formalising some algebra in LaTTe. A lot of concepts there revolved around dependent pairs, so I thought it could be a nice exercise to try add them to Latte.

I've written an executable notebook https://nextjournal.com/zampino/latte-sigma to explore sigma types and dependent pairs running the code of the fork (and posing some questions :-). If you have an account on nextjournal, I can add you as collaborator there, so that you can run the code. Or you can remix it under your profile.

In the notebook I'm showing modeling of the existential quantifier in terms of a Σ-type and the possibility of defining struct like types via combinations of Σ-types. That seems to work already at this stage of the changes. Here is a _static_ summary :-)

```clojure
(definition ex-sigma-def
  "The existential quantifier via Σ type"
  [[T :type][P (==> T :type)]]
  (Σ [x T] (P x)))

(defimplicit ex'
  "The existential quantifier, expressed implicitely via Σ types"
  [def-env ctx [P P-ty]]
  (let [[T _] (p/decompose-impl-type def-env ctx P-ty)]
    (list #'ex-sigma-def T P)))

(defthm ex-sigma-elim-thm
  "Σ-Existential Quantifier Elimination "
  [[T :type][P (==> T :type)][A :type]]
  (==> (ex' P)
       (forall [x T] (==> (P x) A))
       A))

(try-proof 'ex-sigma-elim-thm
  (qed
    (λ [p (Σ [t T] (P t))]
      (λ [f (Π [x T] (==> (P x) A))]
        (f (pr1 p) (pr2 p))))))

;; longer proof
(try-proof 'ex-sigma-elim-thm
  (assume [p (ex' P)
           f (∀ [x T] (==> (P x) A))]
    (have g (==> (P (pr1 p)) A) :by (f (pr1 p)))
    (have a A :by (g (pr2 p))))
  (qed a))

(defthm ex-sigma-intro-thm
  "Σ-Existential Quantifier Introduction"
  [[T :type][P (==> T :type)][t T]]
  (==> (P t) (ex' P)))

(try-proof 'ex-sigma-intro-thm
  (qed (λ [x (P t)] (pair t x))))

;; longer proof
(try-proof 'ex-sigma-intro-thm
  (assume [w (P t)]
    (have q (ex' P) :by (pair t w)))

  (qed q))
```

For calculating type of pairs, I've been following the reduction rules in the book (sorry for the screenshot).

![Screenshot 2019-07-12 at 17 56 11](https://user-images.githubusercontent.com/1078464/61141664-59e66380-a4ce-11e9-99e0-dfe90399e0c4.png)

Far from being ready to merge, in opening an early stage PR I wanted to gauge your possible interest in this or getting some suggestions in general. Maybe defining a roadmap or maybe closing it if it's out of scope for the project? It should be only accretive and shouldn't impact the rest of the kernel functionalities.
