### PR TITLE
Add deps.edn and Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/latte-kernel
+    docker:
+      - image: circleci/clojure:openjdk-11-tools-deps-1.10.0.442
+    steps:
+      - checkout
+      - run: clojure -A:test

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .lein-plugins/
 .lein-failures
 .nrepl-port
+.cpcache

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The (very) small kernel of the LaTTe proof assistant in Clojure(script)
 
-[![Clojars Project](https://img.shields.io/clojars/v/latte-kernel.svg)](https://clojars.org/latte-kernel)
+[![CircleCI](https://circleci.com/gh/latte-central/latte-kernel.svg?style=svg)](https://circleci.com/gh/latte-central/latte-kernel)[![Clojars Project](https://img.shields.io/clojars/v/latte-kernel.svg)](https://clojars.org/latte-kernel)
 
 ```
   _.--'"'.

--- a/codox/codox.clj
+++ b/codox/codox.clj
@@ -1,0 +1,23 @@
+(ns codox
+  "Codox Runner to be operated via Clojure CLI
+
+   Usage: clj -A:codox"
+  (:gen-class)
+  (:require [codox.main :as codox]))
+
+(def options
+  {:source-paths ["src"]
+   :output-path "docs"
+   :metadata {:doc/format :markdown}
+   :namespaces []
+   :name "LaTTe"
+   :license {:name "MIT Licence"
+             :url "http://opensource.org/licenses/MIT"}
+   #_#_
+   :root-path "src"
+   :description "LaTTe : a Laboratory for Type Theory Experiments"
+   :version "1.0b7-SNAPSHOT"})
+
+(defn -main []
+  (println "Codox Starting")
+  (codox/generate-docs options))

--- a/codox/codox.clj
+++ b/codox/codox.clj
@@ -13,9 +13,8 @@
    :name "LaTTe"
    :license {:name "MIT Licence"
              :url "http://opensource.org/licenses/MIT"}
-   #_#_
    :root-path "src"
-   :description "LaTTe : a Laboratory for Type Theory Experiments"
+   :description "The (very) small kernel of the LaTTe proof assistant"
    :version "1.0b7-SNAPSHOT"})
 
 (defn -main []

--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,17 @@
-{:paths ["src"]}
+{:paths ["src"]
+ :deps
+ {org.clojure/clojure {:mvn/version "1.10.1"}
+  org.clojure/clojurescript {:mvn/version "1.10.439"}}
+
+ :aliases
+ {:codox
+  {:extra-paths ["src" "codox"]
+   :main-opts ["-m" "codox"]
+   :extra-deps {codox {:mvn/version "0.10.7"}}}
+
+  :test
+  {:extra-paths ["test"]
+   :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-541"}}
+   :main-opts ["-m" "kaocha.runner"
+               "--reporter" "kaocha.report/documentation"
+               "--plugin" "kaocha.plugin/print-invocations"]}}}


### PR DESCRIPTION
Depsifies and CI-fies the Kernel

- [x] add deps.edn
- [x] configure Circle CI 
- [ ] Make tests green

I couldn't find an immediate replacement for `lein-cljsbuild`. As a future improvement, we'll add cljs build profile probably with figwheel.main https://figwheel.org/docs/create_a_build.html#running-a-build)
.