### PR TITLE
Fix type-checking operand type in application

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,8 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-541"}}
+   :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-541"}
+                nubank/matcher-combinators {:mvn/version "1.2.1"}}
    :main-opts ["-m" "kaocha.runner"
                "--reporter" "kaocha.report/documentation"
                "--plugin" "kaocha.plugin/print-invocations"]}}}

--- a/src/latte_kernel/typing.cljc
+++ b/src/latte_kernel/typing.cljc
@@ -4,7 +4,7 @@
             [latte-kernel.norm :as norm]
             [latte-kernel.defenv :as defenv]
             [latte-kernel.presyntax :as prestx]))
-  
+
 ;;{
 ;; # Type checking
 ;;
@@ -20,7 +20,7 @@
 ;;
 ;; We simply use a vector for the type context, which allows to
 ;; maintain the scoping rules at the price of some inefficiency
-;; (fetching is O(n)). 
+;; (fetching is O(n)).
 ;;}
 
 (defn ctx-fetch
@@ -62,7 +62,7 @@
 (declare unfold-implicit)
 
 (defn type-of-term
-  "Infer the type of term `t` in definitional environment `def-env` 
+  "Infer the type of term `t` in definitional environment `def-env`
   and type context `ctx`.
   The returned value is of the form `[:ok <type> t']` if the inferred
   type is `<type>`, or `[:ko <info> nil]` in case of failure, with `<info>`
@@ -126,7 +126,7 @@ that implicits can be erased."
 ;;
 ;; **Remark**: LaTTe uses an *impredicative* type theory, marked by the fact that
 ;; the kind `□` itself has no type.
-;;  
+;;
 ;;     --------------------
 ;;     E |- Type ::> Kind
 ;;
@@ -154,7 +154,7 @@ that implicits can be erased."
   "Infer the type of variable `x` in context `ctx`."
   [def-env ctx x]
   (if-let [ty (ctx-fetch ctx x)]
-    (let [[status sort ty']                         
+    (let [[status sort ty']
           (let [ty' (norm/normalize def-env ctx ty)]
             (if (stx/kind? ty')
               [:ok ty' ty]
@@ -267,22 +267,21 @@ that implicits can be erased."
       (let [[status trand rand'] (type-of-term def-env ctx rand)]
         (if (= status :ko)
           [:ko {:msg "Cannot calculate operand (right-hand) type in application."
-                :term [rator rand] :from trand} nil])
-        (let [trator' (norm/normalize def-env ctx trator)]
-          (if (not (stx/prod? trator'))
-            [:ko {:msg "Not a product type for operator (left-hand) in application." :term [rator rand] :operator-type trator}]
-            (let [[_ [x A] B] trator']
-              ;; (println "[type-of-app] trator'=" trator')
-              (if (not (type-check? def-env ctx rand A)) ;; or rand' ? (not (type-check? def-env ctx rand' A))
-                [:ko {:msg "Cannot apply: type domain mismatch" :term [rator rand] :domain A :operand rand}]
-                (do ;;(println "[type-of-app] subst...")
-                  ;;(println "    B = " B)
-                  ;;(println "    x = " x)
-                  ;;(println "    rand = " rand)
-                  (let [res (stx/subst B x rand) ;; or rand' ? (stx/subst B x rand')
-                        ]
-                    ;;(println "   ===> " res)
-                    [:ok res [rator' rand']]))))))))))
+                :term [rator rand] :from trand} nil]
+          (let [trator' (norm/normalize def-env ctx trator)]
+            (if (not (stx/prod? trator'))
+              [:ko {:msg "Not a product type for operator (left-hand) in application." :term [rator rand] :operator-type trator}]
+              (let [[_ [x A] B] trator']
+                ;; (println "[type-of-app] trator'=" trator')
+                (if (not (type-check? def-env ctx rand A)) ;; or rand' ? (not (type-check? def-env ctx rand' A))
+                  [:ko {:msg "Cannot apply: type domain mismatch" :term [rator rand] :domain A :operand rand}]
+                  (do ;;(println "[type-of-app] subst...")
+                    ;;(println "    B = " B)
+                    ;;(println "    x = " x)
+                    ;;(println "    rand = " rand)
+                    (let [res (stx/subst B x rand)] ;; or rand' ? (stx/subst B x rand')
+                      ;;(println "   ===> " res)
+                      [:ok res [rator' rand']])))))))))))
 
 ;;{
 ;;
@@ -382,8 +381,8 @@ that implicits can be erased."
             ;;     [:ko err nil]
             ;;     [:ok typ' (list* name args')]))
             ;; [:ok typ (list* name args')] ;;  no unfold (???)
-            [:ok typ (list* name args)]
-            ))))))
+            [:ok typ (list* name args)]))))))
+
 
 
 (defn type-of-args
@@ -450,7 +449,7 @@ that implicits can be erased."
 (defn unfold-implicit [def-env ctx implicit-def args]
   (let [[status, targs, args'] (type-of-implicit-args def-env ctx args)]
     (if (= status :ko)
-      [:ko targs]    
+      [:ko targs]
       (try [:ok, (apply (:implicit-fn implicit-def) def-env ctx targs), args']
            (catch Exception exc
              [:ko (merge {:implicit (:name implicit-def)
@@ -489,5 +488,3 @@ that implicits can be erased."
    (let [ty (type-of def-env ctx t)]
      (let [sort (norm/normalize def-env ctx ty)]
        (stx/sort? sort)))))
-
-


### PR DESCRIPTION
There's a branch in control flow of `type-of-app` function which has no effect.

- [x] reproduce issue in a test
- [x] fix the thing