### PR TITLE
Normalisation by evaluation 3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,9 @@
   :url "https://github.com/latte-central/latte-kernel.git"
   :license {:name "MIT Licence"
             :url "http://opensource.org/licenses/MIT"}
-  ;; :dependencies []
   :codox {:output-path "docs"
-          :metadata {:doc/format :markdown}
+          :metadata {:doc/format :markdown}}
           ;;:namespaces []
-          }
   :plugins [[lein-cljsbuild "1.1.7"]]
   :cljsbuild {
               :builds [{:source-paths ["src-cljs"]
@@ -19,7 +17,5 @@
                     [org.clojure/clojurescript "1.10.439"]
                     [cider/piggieback "0.3.10"]
                     [lambdaisland/kaocha "0.0-541"]
-                    [nubank/matcher-combinators "1.2.1"]
-                    ]}
+                    [nubank/matcher-combinators "1.2.1"]]}
              :test {:dependencies [[org.clojure/clojure "1.10.1"]]}})
-

--- a/src/latte_kernel/Makefile
+++ b/src/latte_kernel/Makefile
@@ -1,4 +1,3 @@
-
 MARKDOWNIZE_PATH = ../../../markdownize
 PYTHON = python3
 
@@ -18,6 +17,3 @@ markdownize: $(OBJS)
 clean:
 	rm -f *~
 	rm -f *.md
-
-
-

--- a/src/latte_kernel/defenv.cljc
+++ b/src/latte_kernel/defenv.cljc
@@ -41,7 +41,7 @@
 (defn mkenv [env] [env {}])
 
 (defn local-definitions [env]
-(second env))
+  (second env))
 
 (defn register-definition
   ([def-env rdef] (register-definition def-env rdef false))
@@ -70,7 +70,7 @@
   In the Clojure (not Clojurescript) version the definition is also sought in the current namespace.
 
   If the optional argument `local-only?` is set to `true` then the definition is
- looked for in `def-env` and only for definition tagged \"local\". In any case the current namespace
+  looked for in `def-env` and only for definition tagged \"local\". In any case the current namespace
   is not considered. In Clojurescript the namespace is not considered anyways. The flag is `false` by default."
   ([def-env dname] (fetch-definition def-env dname false))
   ([def-env dname local-only?]

--- a/src/latte_kernel/nbe.cljc
+++ b/src/latte_kernel/nbe.cljc
@@ -1,0 +1,115 @@
+(ns latte-kernel.nbe
+  (:require [latte-kernel.syntax :as stx]))
+
+(defn evaluation
+  "Convert from LaTTe internal syntax to nbe-specific syntax, recursively.
+  All terms are just translated into pair with a special keyword,
+  excepts lambdas which are turned into real Clojure functions, quoted to avoid
+  calling nested function in bottom-up manner."
+ ([t] (evaluation t #{}))
+ ([t bound]
+  {:pre [(stx/term? t)]}
+  (cond
+    ;; sort
+    (stx/sort? t)
+    [::sort (keyword "latte-kernel.nbe" (str t))]
+
+    ;; previously bound variable
+    (and (stx/variable? t) (contains? bound t))
+    t
+
+    ;; normal variable
+    (stx/variable? t)
+    [::var (keyword "latte-kernel.nbe" (str t))]
+
+    ;; lambda
+    (stx/lambda? t)
+    (let [[_ [x tx] body] t
+          body2 (evaluation body (conj bound x))]
+      [::lambda
+       (with-meta (list 'fn [x] body2)
+         {::var-name (keyword "latte-kernel.nbe" (str x))
+          ::var-type (evaluation tx bound)})])
+
+    ;; pi
+    (stx/prod? t)
+    (let [[_ [x tx] body] t]
+      [::pi
+       (with-meta (evaluation body (conj bound x))
+         {::var-name (keyword "latte-kernel.nbe" (str x))
+          ::var-type (evaluation tx bound)})])
+
+    ;; reference
+    (stx/ref? t)
+    (let [[ref-name & args] t
+          args' (map #(evaluation % bound) args)]
+      (vec (cons ::ref (cons ref-name args'))))
+
+    ;; application
+    (stx/app? t)
+    (let [u (evaluation (first t) bound)
+          u' (evaluation (second t) bound)]
+      [::app u u'])
+
+    ;; ascription
+    (stx/ascription? t)
+    [::asc (evaluation (second t) bound) (evaluation (last t) bound)]
+
+    ;; host constants
+    (stx/host-constant? t)
+    t)))
+
+(defn normalisation
+  "Actually apply normalisation, staying in nbe-specific syntax."
+  [t]
+  (if (or (stx/variable? t) (stx/host-constant? t))
+    t
+    (case (first t)
+      ::sort t
+      ::var t
+      ::lambda (let [f (second t)
+                     var-type (normalisation (::var-type (meta f)))]
+                 [::lambda (vary-meta f assoc ::var-type var-type)])
+      ::pi (let [body (second t)
+                 var-name (::var-name (meta body))
+                 var-type (normalisation (::var-type (meta body)))]
+             [::pi (with-meta (normalisation body)
+                     {::var-type var-type, ::var-name var-name})])
+      ::app (let [[_ l r] t
+                  l' (normalisation l)
+                  r' (normalisation r)]
+              (if (and (vector? l') (= ::lambda (first l')))
+                ;; We can apply the function contained in l'
+                ((eval (second l')) r')
+                [::app l' r']))
+      ::ref (vec (cons (second t) (nth t 2)))
+      ::asc [::asc (normalisation (second t)) (normalisation (last t))])))
+
+(defn quotation
+  "From nbe-specific syntax to normal LaTTe internal syntax."
+  [t]
+  {:post [(stx/term? %)]}
+  (if (or (stx/variable? t) (stx/host-constant? t))
+    t
+    (case (first t)
+      (::sort ::var) (symbol (name (second t)))
+      ::lambda (let [f (second t)
+                     var-name (-> f meta ::var-name name symbol)
+                     var-type (-> f meta ::var-type quotation)]
+                 ;; f has never been called, so the body wasn't reduced.
+                 ;; We call it with the associated variable to unfold everything
+                 (list 'λ [var-name var-type] (quotation (normalisation ((eval f) var-name)))))
+      ::pi (let [body (second t)
+                 var-name (-> body meta ::var-name name symbol)
+                 var-type (-> body meta ::var-type quotation)]
+             (list 'Π [var-name var-type] (quotation body)))
+      ::app [(quotation (second t)) (quotation (last t))]
+      ::ref (vec (cons (second t) (nth t 2)))
+      ::asc (list ::stx/ascribe (quotation (second t)) (quotation (last t))))))
+
+(defn norm
+  "Compose above functions to create the 'normalisation by evaluation' process."
+  [t]
+  {:pre [(stx/term? t)]
+   :post [(stx/term? %), (nil? (meta %))]}
+  ((comp quotation normalisation evaluation) t))

--- a/src/latte_kernel/norm.cljc
+++ b/src/latte_kernel/norm.cljc
@@ -26,7 +26,7 @@
 ;;   1. *strong normalization*: it is not possible to rewrite a given term infinitely, which
 ;;   means that the normalization algorithm must terminate.
 ;;
-;;   2. *confluence*: different strategies can be followed for reducing a given term - 
+;;   2. *confluence*: different strategies can be followed for reducing a given term -
 ;;   the normalization process is non-deterministics - but the ultimate result must be the same (up-to alpha-equivalence)
 ;;
 ;; Strong normalization is as its name implies a very strong constraint, and in general
@@ -100,19 +100,19 @@
 ;; spending too much time looking for them, but also ensuring
 ;; that all of them are found. LaTTe focuses on the latter.
 ;;}
-  
-  
+
+
 (declare beta-step-args)
 
 (defn beta-step
   "A call to this function will reduce a (somewhat)
   arbitrary number of *redexes* in term `t`
-   using a mostly bottom-up strategy, and reducing
- all terms at the same level (e.g. definition arguments).
+  using a mostly bottom-up strategy, and reducing
+  all terms at the same level (e.g. definition arguments).
 
-The return value is a pair `[t' red?]` with `t'` the
-potentially rewritten version of `t` and `red?` is `true`
- iff at least one redex was found and reduced."
+  The return value is a pair `[t' red?]` with `t'` the
+  potentially rewritten version of `t` and `red?` is `true`
+  iff at least one redex was found and reduced."
   ([t] (beta-step t 0))
   ([t rcount]
    (cond
@@ -153,7 +153,7 @@ potentially rewritten version of `t` and `red?` is `true`
      :else [t rcount])))
 
 (defn beta-step-args
-  "Apply the reduction strategy on the terms `ts` 
+  "Apply the reduction strategy on the terms `ts`
   in *\"parallel\"*. This is one place
   where many redexes can be found at once.
   This returns a pair composed of the rewritten
@@ -201,7 +201,7 @@ potentially rewritten version of `t` and `red?` is `true`
 ;;}
 
 (defn instantiate-def
-  "Substitute in the `body` of a definition the parameters `params` 
+  "Substitute in the `body` of a definition the parameters `params`
   by the actual arguments `args`."
   [params body args]
   ;;(println "[instantiate-def] params=" params "body=" body "args=" args)
@@ -289,7 +289,7 @@ potentially rewritten version of `t` and `red?` is `true`
 
 (defn delta-step
   "Applies the strategy of *delta-reduction* on term `t` with definitional
- environment `def-env`. If the optional flag `local?` is `true` only the
+  environment `def-env`. If the optional flag `local?` is `true` only the
   local environment is used, otherwise (the default case) the definitions
   are also searched in the current namespace (in Clojure only)."
   ([def-env ctx t] (delta-step def-env ctx t false 0))
@@ -402,7 +402,7 @@ potentially rewritten version of `t` and `red?` is `true`
         [t'' beta-count] (beta-step t')]
     ;; (println "[Info] delta-count=" delta-count ", beta-count=" beta-count)
     t''))
-    
+
 ;;{
 ;; The following is the main user-level function for normalization.
 ;;}
@@ -429,7 +429,7 @@ potentially rewritten version of `t` and `red?` is `true`
 
 (defn beta-eq?
   "Are terms `t1` and `t2` equivalent, i.e. with the
-same normal form (up-to alpha-convertion)?"
+  same normal form (up-to alpha-convertion)?"
   ([t1 t2]
    (let [t1' (normalize t1)
          t2' (normalize t2)]
@@ -442,4 +442,3 @@ same normal form (up-to alpha-convertion)?"
    (let [t1' (normalize def-env ctx t1)
          t2' (normalize def-env ctx t2)]
      (stx/alpha-eq? t1' t2'))))
-

--- a/src/latte_kernel/norm.cljc.md
+++ b/src/latte_kernel/norm.cljc.md
@@ -28,7 +28,7 @@
    1. *strong normalization*: it is not possible to rewrite a given term infinitely, which
    means that the normalization algorithm must terminate.
 
-   2. *confluence*: different strategies can be followed for reducing a given term - 
+   2. *confluence*: different strategies can be followed for reducing a given term -
    the normalization process is non-deterministics - but the ultimate result must be the same (up-to alpha-equivalence)
 
  Strong normalization is as its name implies a very strong constraint, and in general
@@ -104,20 +104,20 @@
  spending too much time looking for them, but also ensuring
  that all of them are found. LaTTe focuses on the latter.
 
+
+
 ```clojure
-  
-  
 (declare beta-step-args)
 
 (defn beta-step
   "A call to this function will reduce a (somewhat)
   arbitrary number of *redexes* in term `t`
-   using a mostly bottom-up strategy, and reducing
- all terms at the same level (e.g. definition arguments).
+  using a mostly bottom-up strategy, and reducing
+  all terms at the same level (e.g. definition arguments).
 
-The return value is a pair `[t' red?]` with `t'` the
-potentially rewritten version of `t` and `red?` is `true`
- iff at least one redex was found and reduced."
+  The return value is a pair `[t' red?]` with `t'` the
+  potentially rewritten version of `t` and `red?` is `true`
+  iff at least one redex was found and reduced."
   ([t] (beta-step t 0))
   ([t rcount]
    (cond
@@ -158,7 +158,7 @@ potentially rewritten version of `t` and `red?` is `true`
      :else [t rcount])))
 
 (defn beta-step-args
-  "Apply the reduction strategy on the terms `ts` 
+  "Apply the reduction strategy on the terms `ts`
   in *\"parallel\"*. This is one place
   where many redexes can be found at once.
   This returns a pair composed of the rewritten
@@ -208,7 +208,7 @@ potentially rewritten version of `t` and `red?` is `true`
 
 ```clojure
 (defn instantiate-def
-  "Substitute in the `body` of a definition the parameters `params` 
+  "Substitute in the `body` of a definition the parameters `params`
   by the actual arguments `args`."
   [params body args]
   ;;(println "[instantiate-def] params=" params "body=" body "args=" args)
@@ -300,7 +300,7 @@ potentially rewritten version of `t` and `red?` is `true`
 
 (defn delta-step
   "Applies the strategy of *delta-reduction* on term `t` with definitional
- environment `def-env`. If the optional flag `local?` is `true` only the
+  environment `def-env`. If the optional flag `local?` is `true` only the
   local environment is used, otherwise (the default case) the definitions
   are also searched in the current namespace (in Clojure only)."
   ([def-env ctx t] (delta-step def-env ctx t false 0))
@@ -417,7 +417,7 @@ potentially rewritten version of `t` and `red?` is `true`
         [t'' beta-count] (beta-step t')]
     ;; (println "[Info] delta-count=" delta-count ", beta-count=" beta-count)
     t''))
-    
+
 ```
 
  The following is the main user-level function for normalization.
@@ -448,7 +448,7 @@ potentially rewritten version of `t` and `red?` is `true`
 ```clojure
 (defn beta-eq?
   "Are terms `t1` and `t2` equivalent, i.e. with the
-same normal form (up-to alpha-convertion)?"
+  same normal form (up-to alpha-convertion)?"
   ([t1 t2]
    (let [t1' (normalize t1)
          t2' (normalize t2)]
@@ -461,5 +461,4 @@ same normal form (up-to alpha-convertion)?"
    (let [t1' (normalize def-env ctx t1)
          t2' (normalize def-env ctx t2)]
      (stx/alpha-eq? t1' t2'))))
-
 ```

--- a/src/latte_kernel/norm.cljc.md
+++ b/src/latte_kernel/norm.cljc.md
@@ -1,10 +1,14 @@
 ```clojure
 (ns latte-kernel.norm
   "Normalization and beta-equivalence."
-  (:require [latte-kernel.utils :as utils :refer [vconcat]]
-            [latte-kernel.syntax :as stx]
-            [latte-kernel.defenv :as defenv :refer [definition? theorem? axiom?]]))
+  (:require [latte-kernel.syntax :as stx]
+            [latte-kernel.defenv :as defenv :refer [definition? theorem? axiom?]]
+            [latte-kernel.nbe :as nbe]))
 
+(def norm-type
+  ;:beta-norm)
+  ;:nbe)
+  :both)
 
 ```
 
@@ -83,7 +87,6 @@
   (and (stx/app? t)
        (stx/lambda? (first t))))
 
-
 (defn beta-reduction
   "The basic rule of *beta-reduction* for term `t`.
   Note that the term `t` must already be a *redex*
@@ -103,7 +106,6 @@
  must be implemented. It is a kind of a *black art* of not
  spending too much time looking for them, but also ensuring
  that all of them are found. LaTTe focuses on the latter.
-
 
 
 ```clojure
@@ -174,9 +176,15 @@
 (defn beta-red
   "Reduce term `t` according to the normalization strategy."
   [t]
-  (let [[t' _] (beta-step t)]
-    t'))
-
+  (case norm-type
+    :beta-norm (first (beta-step t))
+    :nbe (nbe/norm t)
+    :both (let [[beta-t _] (beta-step t)
+                nbe-t (nbe/norm t)]
+            (if (stx/alpha-eq? beta-t nbe-t)
+              beta-t
+              (throw (ex-info "Terms not alpha-equivalent in nbe/beta-norm."
+                       {:beta-term beta-t, :nbe-term nbe-t}))))))
 
 ```
 
@@ -361,13 +369,6 @@
 
 
 ```clojure
-(defn beta-normalize
-  "Normalize term `t` for beta-reduction."
-  [t]
-  (let [[t' rcount] (beta-step t)]
-    ;;(println "[INFO] Number of beta-reductions=" rcount)
-    t'))
-
 (defn delta-normalize
   "Normalize term `t` for delta-reduction."
   [def-env ctx t]
@@ -413,10 +414,17 @@
   The result is defined as *the normal form* of `t`."
   [def-env ctx t]
   ;;(println "[beta-delta-normalize]: t=" t)
-  (let [[t' delta-count] (delta-step def-env ctx t)
-        [t'' beta-count] (beta-step t')]
+  (let [[t' _] (delta-step def-env ctx t)]
     ;; (println "[Info] delta-count=" delta-count ", beta-count=" beta-count)
-    t''))
+    (case norm-type
+      :beta-norm (first (beta-step t'))
+      :nbe (nbe/norm t')
+      :both (let [[beta-t _] (beta-step t')
+                  nbe-t (nbe/norm t')]
+              (if (stx/alpha-eq? beta-t nbe-t)
+                beta-t
+                (throw (ex-info "Terms not alpha-equivalent in nbe/beta-norm."
+                         {:beta-term beta-t, :nbe-term nbe-t})))))))
 
 ```
 

--- a/src/latte_kernel/presyntax.cljc
+++ b/src/latte_kernel/presyntax.cljc
@@ -1,7 +1,7 @@
 
 (ns latte-kernel.presyntax
   "The rich syntax of the lambda-calculus implemented
-by LaTTe."
+  by LaTTe."
   (:require [latte-kernel.defenv :as defenv]))
 
 ;;{
@@ -196,7 +196,7 @@ by LaTTe."
 ;;
 ;; There are two kinds of abstractions in LaTTe:
 ;;   - lambda abstractions, i.e. unary unanymous functions of the form `(λ [x t] u)`
-;;   - product abstractions, a.k.a. "Pi-types" (also) universal quantifications of the form `(Π [x t] u)` 
+;;   - product abstractions, a.k.a. "Pi-types" (also) universal quantifications of the form `(Π [x t] u)`
 ;;
 ;; A simple but useful syntactic sugar is proposed:
 ;;
@@ -333,7 +333,7 @@ by LaTTe."
 ;; Internally, this will become a set of binary applications, of the form:
 ;; `[...[[f e1] e2]... eN]`
 ;;}
-  
+
 (defn left-binarize
   "Binarization (sic!) of an application."
   [t]
@@ -354,6 +354,3 @@ by LaTTe."
       (if (= status :ko)
         [:ko {:msg "Parse error in operand of application" :term t :from ts}]
         [:ok (left-binarize ts)]))))
-
-
-

--- a/src/latte_kernel/presyntax.cljc.md
+++ b/src/latte_kernel/presyntax.cljc.md
@@ -2,7 +2,7 @@
 ```clojure
 (ns latte-kernel.presyntax
   "The rich syntax of the lambda-calculus implemented
-by LaTTe."
+  by LaTTe."
   (:require [latte-kernel.defenv :as defenv]))
 
 ```
@@ -210,7 +210,7 @@ by LaTTe."
 
  There are two kinds of abstractions in LaTTe:
    - lambda abstractions, i.e. unary unanymous functions of the form `(λ [x t] u)`
-   - product abstractions, a.k.a. "Pi-types" (also) universal quantifications of the form `(Π [x t] u)` 
+   - product abstractions, a.k.a. "Pi-types" (also) universal quantifications of the form `(Π [x t] u)`
 
  A simple but useful syntactic sugar is proposed:
 
@@ -353,8 +353,8 @@ by LaTTe."
  Internally, this will become a set of binary applications, of the form:
  `[...[[f e1] e2]... eN]`
 
+
 ```clojure
-  
 (defn left-binarize
   "Binarization (sic!) of an application."
   [t]
@@ -375,7 +375,4 @@ by LaTTe."
       (if (= status :ko)
         [:ko {:msg "Parse error in operand of application" :term t :from ts}]
         [:ok (left-binarize ts)]))))
-
-
-
 ```

--- a/src/latte_kernel/proof.cljc
+++ b/src/latte_kernel/proof.cljc
@@ -55,7 +55,7 @@
 (defn elab-have [def-env ctx var-deps def-uses name ty term meta]
   ;;(println "  => have step: " name)
   (let [[status res] (elab-have-impl def-env ctx var-deps def-uses name ty term meta)]
-[status res]))
+   [status res]))
 
 (defn elab-have-impl [def-env ctx var-deps def-uses name ty term meta]
   ;;(println "  => have step: " name)
@@ -83,8 +83,7 @@
                                          :meta meta}]
                                    :else
                                    ;;[:ok term-type] ;; XXX: the have-type is mode "declarative" (?)
-                                   [:ok have-type] ;; largely faster in bad cases !
-                                   )))]
+                                   [:ok have-type])))] ;; largely faster in bad cases !
         (if (= status :ko)
           [:ko (assoc rec-ty :meta meta)]
           (if (= name '_)
@@ -112,8 +111,7 @@
           ;;                                    (conj deps name)
           ;;                                    deps)]))
           ;; ^^^ old version ^^^
-          (recur (rest vdeps) (conj res [v (conj deps name)]))
-          )
+          (recur (rest vdeps) (conj res [v (conj deps name)])))
         res))))
 
 (defn ref-uses-in-term [t]
@@ -295,7 +293,7 @@
   (println "local definitions:")
   (doseq [[name ddef] (defenv/local-definitions def-env)]
     (println name (str "(" (show-deftype ddef) "):") (show-def ddef meta)))
-(println "============================"))
+ (println "============================"))
 
 ;;{
 ;; ## Proof elabortation
@@ -303,7 +301,7 @@
 ;; The proof elaborator simply iterates over the proof steps
 ;; and dispatch to the adequate elaboration function.
 ;;
-;; All the parsing issues are managed by the elaborator. 
+;; All the parsing issues are managed by the elaborator.
 ;;}
 
 (defn print-state [msg def-env ctx var-deps def-uses]
@@ -313,7 +311,7 @@
   (println "  var-deps=" var-deps)
   (println "  def-uses=" def-uses))
 
-(defn elab-proof-step [def-env ctx var-deps def-uses step args] 
+(defn elab-proof-step [def-env ctx var-deps def-uses step args]
   (case step
     :declare
     (let [[v ty-expr meta] args
@@ -454,13 +452,13 @@
                                    [:discharge x meta]) (reverse params)))
                     ;; no more assumptions after an assume
                     ()])
-                   (contains? #{:have :qed :print-term :print-type :print-def :print-defenv} (ffirst proof))
+                 (contains? #{:have :qed :print-term :print-type :print-def :print-defenv} (ffirst proof))
                    ;; XXX: cannot use goal assumptions after a non-assume step
                  [(list (first proof)) ()]
                  :else
                  (throw (ex-info "Compilation failed: unsupported proof step." {:step (first proof)})))]
-           ;; in the let        
-           (concat 
+           ;; in the let
+           (concat
             steps
             (compile-proof goal-assumptions' (rest proof)))))
      ;; the end
@@ -483,8 +481,3 @@
                   :thm-type thm-type'
                   :proof-type proof-type}]
             [:ok [proof-term proof-type]]))))))
-
-
-
-
-

--- a/src/latte_kernel/proof.cljc.md
+++ b/src/latte_kernel/proof.cljc.md
@@ -60,7 +60,7 @@
 (defn elab-have [def-env ctx var-deps def-uses name ty term meta]
   ;;(println "  => have step: " name)
   (let [[status res] (elab-have-impl def-env ctx var-deps def-uses name ty term meta)]
-[status res]))
+   [status res]))
 
 (defn elab-have-impl [def-env ctx var-deps def-uses name ty term meta]
   ;;(println "  => have step: " name)
@@ -88,8 +88,7 @@
                                          :meta meta}]
                                    :else
                                    ;;[:ok term-type] ;; XXX: the have-type is mode "declarative" (?)
-                                   [:ok have-type] ;; largely faster in bad cases !
-                                   )))]
+                                   [:ok have-type])))] ;; largely faster in bad cases !
         (if (= status :ko)
           [:ko (assoc rec-ty :meta meta)]
           (if (= name '_)
@@ -117,8 +116,7 @@
           ;;                                    (conj deps name)
           ;;                                    deps)]))
           ;; ^^^ old version ^^^
-          (recur (rest vdeps) (conj res [v (conj deps name)]))
-          )
+          (recur (rest vdeps) (conj res [v (conj deps name)])))
         res))))
 
 (defn ref-uses-in-term [t]
@@ -304,7 +302,7 @@
   (println "local definitions:")
   (doseq [[name ddef] (defenv/local-definitions def-env)]
     (println name (str "(" (show-deftype ddef) "):") (show-def ddef meta)))
-(println "============================"))
+ (println "============================"))
 
 ```
 
@@ -313,7 +311,7 @@
  The proof elaborator simply iterates over the proof steps
  and dispatch to the adequate elaboration function.
 
- All the parsing issues are managed by the elaborator. 
+ All the parsing issues are managed by the elaborator.
 
 
 ```clojure
@@ -324,7 +322,7 @@
   (println "  var-deps=" var-deps)
   (println "  def-uses=" def-uses))
 
-(defn elab-proof-step [def-env ctx var-deps def-uses step args] 
+(defn elab-proof-step [def-env ctx var-deps def-uses step args]
   (case step
     :declare
     (let [[v ty-expr meta] args
@@ -465,13 +463,13 @@
                                    [:discharge x meta]) (reverse params)))
                     ;; no more assumptions after an assume
                     ()])
-                   (contains? #{:have :qed :print-term :print-type :print-def :print-defenv} (ffirst proof))
+                 (contains? #{:have :qed :print-term :print-type :print-def :print-defenv} (ffirst proof))
                    ;; XXX: cannot use goal assumptions after a non-assume step
                  [(list (first proof)) ()]
                  :else
                  (throw (ex-info "Compilation failed: unsupported proof step." {:step (first proof)})))]
-           ;; in the let        
-           (concat 
+           ;; in the let
+           (concat
             steps
             (compile-proof goal-assumptions' (rest proof)))))
      ;; the end
@@ -494,9 +492,4 @@
                   :thm-type thm-type'
                   :proof-type proof-type}]
             [:ok [proof-term proof-type]]))))))
-
-
-
-
-
 ```

--- a/src/latte_kernel/syntax.cljc
+++ b/src/latte_kernel/syntax.cljc
@@ -1,4 +1,3 @@
-
 (ns latte-kernel.syntax
   "The internal representation of lambda-terms."
   (:require [clojure.set :as set]
@@ -108,8 +107,8 @@
 ;; result from parsing a term in the user-level syntax.
 
 ;; As a safety measure we use the word *ascription* that a user will unlikely
-;; use its own code. Moreover, the keyword is namespaces so these should
-;; be enought to emphasis the fact that ascriptions are *dangerous* and
+;; use its own code. Moreover, the keyword is namespaced so these should
+;; be enough to emphasis the fact that ascriptions are *dangerous* and
 ;; only used inside the kernel...
 ;;}
 
@@ -127,7 +126,7 @@
 ;;}
 
 (defn host-constant?
-  "Is `t` a constant provided by the host ?"
+  "Is `t` a constant provided by the host?"
   [t]
   (and (vector? t)
        (= (count t) 2)
@@ -213,8 +212,8 @@
     (app? t) (set/union (free-vars (first t))
                         (free-vars (second t)))
     (ascription? t) (let [[_ e u] t]
-                  (set/union (free-vars e)
-                             (free-vars u)))
+                     (set/union (free-vars e)
+                                (free-vars u)))
     (ref? t) (apply set/union (map free-vars (rest t)))
     :else #{}))
 
@@ -228,7 +227,7 @@
     (app? t) (set/union (vars (first t))
                         (vars (second t)))
     (ascription? t) (let [[_ e u] t]
-                  (set/union (vars e) (vars u)))
+                     (set/union (vars e) (vars u)))
     (ref? t) (apply set/union (map vars (rest t)))
     :else #{}))
 
@@ -255,7 +254,7 @@
 (defn mk-fresh
   "Generate a fresh variable name, with prepfix `base`
   and suffix chosen from ' (quote), '', ''' then -4, -5, etc.
-The `forbid` argument says what names are forbidden."
+  The `forbid` argument says what names are forbidden."
   ([base forbid] (mk-fresh base 0 forbid))
   ([base ^long level forbid]
    (let [suffix (case level
@@ -276,8 +275,8 @@ The `forbid` argument says what names are forbidden."
 (declare rebinder)
 
 (defn- subst-
-  "Applies substituion `sub` on term `t`. 
-Names generated fresh along the substitution cannot be members of `forbid`.
+  "Applies substituion `sub` on term `t`.
+  Names generated fresh along the substitution cannot be members of `forbid`.
   Bound variable may be renamed according to the `rebind` map."
   [t sub forbid rebind]
   (let [[t' forbid']
@@ -368,9 +367,8 @@ Names generated fresh along the substitution cannot be members of `forbid`.
     ;; ascription
     (ascription? t)
     (let [[_ e _] t
-          [e' level'] (alpha-norm- e sub level)
+          [e' level'] (alpha-norm- e sub level)]
           ;; the type part is removed during alpha-normalization
-          ]
       [e' level'])
     ;; references
     (ref? t) (let [[args level']
@@ -424,5 +422,3 @@ Names generated fresh along the substitution cannot be members of `forbid`.
       (if (nil? top)
         v
         (recur t' (conj v top))))))
-          
-           

--- a/src/latte_kernel/syntax.cljc.md
+++ b/src/latte_kernel/syntax.cljc.md
@@ -1,4 +1,3 @@
-
 ```clojure
 (ns latte-kernel.syntax
   "The internal representation of lambda-terms."
@@ -120,8 +119,8 @@
  result from parsing a term in the user-level syntax.
 
  As a safety measure we use the word *ascription* that a user will unlikely
- use its own code. Moreover, the keyword is namespaces so these should
- be enought to emphasis the fact that ascriptions are *dangerous* and
+ use its own code. Moreover, the keyword is namespaced so these should
+ be enough to emphasis the fact that ascriptions are *dangerous* and
  only used inside the kernel...
 
 
@@ -142,7 +141,7 @@
 
 ```clojure
 (defn host-constant?
-  "Is `t` a constant provided by the host ?"
+  "Is `t` a constant provided by the host?"
   [t]
   (and (vector? t)
        (= (count t) 2)
@@ -234,8 +233,8 @@
     (app? t) (set/union (free-vars (first t))
                         (free-vars (second t)))
     (ascription? t) (let [[_ e u] t]
-                  (set/union (free-vars e)
-                             (free-vars u)))
+                     (set/union (free-vars e)
+                                (free-vars u)))
     (ref? t) (apply set/union (map free-vars (rest t)))
     :else #{}))
 
@@ -249,7 +248,7 @@
     (app? t) (set/union (vars (first t))
                         (vars (second t)))
     (ascription? t) (let [[_ e u] t]
-                  (set/union (vars e) (vars u)))
+                     (set/union (vars e) (vars u)))
     (ref? t) (apply set/union (map vars (rest t)))
     :else #{}))
 
@@ -278,7 +277,7 @@
 (defn mk-fresh
   "Generate a fresh variable name, with prepfix `base`
   and suffix chosen from ' (quote), '', ''' then -4, -5, etc.
-The `forbid` argument says what names are forbidden."
+  The `forbid` argument says what names are forbidden."
   ([base forbid] (mk-fresh base 0 forbid))
   ([base ^long level forbid]
    (let [suffix (case level
@@ -301,8 +300,8 @@ The `forbid` argument says what names are forbidden."
 (declare rebinder)
 
 (defn- subst-
-  "Applies substituion `sub` on term `t`. 
-Names generated fresh along the substitution cannot be members of `forbid`.
+  "Applies substituion `sub` on term `t`.
+  Names generated fresh along the substitution cannot be members of `forbid`.
   Bound variable may be renamed according to the `rebind` map."
   [t sub forbid rebind]
   (let [[t' forbid']
@@ -395,9 +394,8 @@ Names generated fresh along the substitution cannot be members of `forbid`.
     ;; ascription
     (ascription? t)
     (let [[_ e _] t
-          [e' level'] (alpha-norm- e sub level)
+          [e' level'] (alpha-norm- e sub level)]
           ;; the type part is removed during alpha-normalization
-          ]
       [e' level'])
     ;; references
     (ref? t) (let [[args level']
@@ -455,6 +453,4 @@ Names generated fresh along the substitution cannot be members of `forbid`.
       (if (nil? top)
         v
         (recur t' (conj v top))))))
-          
-           
 ```

--- a/src/latte_kernel/typing.cljc
+++ b/src/latte_kernel/typing.cljc
@@ -66,8 +66,8 @@
   and type context `ctx`.
   The returned value is of the form `[:ok <type> t']` if the inferred
   type is `<type>`, or `[:ko <info> nil]` in case of failure, with `<info>`
- an error map.  The term `t'` returned is the rewrite of the term so
-that implicits can be erased."
+  an error map.  The term `t'` returned is the rewrite of the term so
+  that implicits can be erased."
   [def-env ctx t]
   (let [[status ty t']
         (cond
@@ -181,8 +181,7 @@ that implicits can be erased."
 ;;}
 
 (defn type-of-prod
-  "Infer the type of a product with bound variable `x` of
-  type `A` in body `B`."
+  "Infer the type of a product with bound variable `x` of type `A` in body `B`."
   [def-env ctx x A B]
   (let [[status sort1 A'] (type-of-term def-env ctx A)]
     (if (= status :ko)
@@ -257,8 +256,7 @@ that implicits can be erased."
 ;;}
 
 (defn type-of-app
-  "Infer the type of an application with operator `rator` and
-  operand `rand`."
+  "Infer the type of an application with operator `rator` and operand `rand`."
   [def-env ctx rator rand]
   (let [[status trator rator'] (type-of-term def-env ctx rator)]
     (if (= status :ko)

--- a/src/latte_kernel/typing.cljc.md
+++ b/src/latte_kernel/typing.cljc.md
@@ -5,7 +5,7 @@
             [latte-kernel.norm :as norm]
             [latte-kernel.defenv :as defenv]
             [latte-kernel.presyntax :as prestx]))
-  
+
 ```
 
  # Type checking
@@ -22,7 +22,7 @@
 
  We simply use a vector for the type context, which allows to
  maintain the scoping rules at the price of some inefficiency
- (fetching is O(n)). 
+ (fetching is O(n)).
 
 
 ```clojure
@@ -69,12 +69,12 @@
 (declare unfold-implicit)
 
 (defn type-of-term
-  "Infer the type of term `t` in definitional environment `def-env` 
+  "Infer the type of term `t` in definitional environment `def-env`
   and type context `ctx`.
   The returned value is of the form `[:ok <type> t']` if the inferred
   type is `<type>`, or `[:ko <info> nil]` in case of failure, with `<info>`
- an error map.  The term `t'` returned is the rewrite of the term so
-that implicits can be erased."
+  an error map.  The term `t'` returned is the rewrite of the term so
+  that implicits can be erased."
   [def-env ctx t]
   (let [[status ty t']
         (cond
@@ -136,7 +136,7 @@ that implicits can be erased."
 
  **Remark**: LaTTe uses an *impredicative* type theory, marked by the fact that
  the kind `□` itself has no type.
-  
+
      --------------------
      E |- Type ::> Kind
 
@@ -167,7 +167,7 @@ that implicits can be erased."
   "Infer the type of variable `x` in context `ctx`."
   [def-env ctx x]
   (if-let [ty (ctx-fetch ctx x)]
-    (let [[status sort ty']                         
+    (let [[status sort ty']
           (let [ty' (norm/normalize def-env ctx ty)]
             (if (stx/kind? ty')
               [:ok ty' ty]
@@ -196,8 +196,7 @@ that implicits can be erased."
 
 ```clojure
 (defn type-of-prod
-  "Infer the type of a product with bound variable `x` of
-  type `A` in body `B`."
+  "Infer the type of a product with bound variable `x` of type `A` in body `B`."
   [def-env ctx x A B]
   (let [[status sort1 A'] (type-of-term def-env ctx A)]
     (if (= status :ko)
@@ -276,8 +275,7 @@ that implicits can be erased."
 
 ```clojure
 (defn type-of-app
-  "Infer the type of an application with operator `rator` and
-  operand `rand`."
+  "Infer the type of an application with operator `rator` and operand `rand`."
   [def-env ctx rator rand]
   (let [[status trator rator'] (type-of-term def-env ctx rator)]
     (if (= status :ko)
@@ -286,22 +284,21 @@ that implicits can be erased."
       (let [[status trand rand'] (type-of-term def-env ctx rand)]
         (if (= status :ko)
           [:ko {:msg "Cannot calculate operand (right-hand) type in application."
-                :term [rator rand] :from trand} nil])
-        (let [trator' (norm/normalize def-env ctx trator)]
-          (if (not (stx/prod? trator'))
-            [:ko {:msg "Not a product type for operator (left-hand) in application." :term [rator rand] :operator-type trator}]
-            (let [[_ [x A] B] trator']
-              ;; (println "[type-of-app] trator'=" trator')
-              (if (not (type-check? def-env ctx rand A)) ;; or rand' ? (not (type-check? def-env ctx rand' A))
-                [:ko {:msg "Cannot apply: type domain mismatch" :term [rator rand] :domain A :operand rand}]
-                (do ;;(println "[type-of-app] subst...")
-                  ;;(println "    B = " B)
-                  ;;(println "    x = " x)
-                  ;;(println "    rand = " rand)
-                  (let [res (stx/subst B x rand) ;; or rand' ? (stx/subst B x rand')
-                        ]
-                    ;;(println "   ===> " res)
-                    [:ok res [rator' rand']]))))))))))
+                :term [rator rand] :from trand} nil]
+          (let [trator' (norm/normalize def-env ctx trator)]
+            (if (not (stx/prod? trator'))
+              [:ko {:msg "Not a product type for operator (left-hand) in application." :term [rator rand] :operator-type trator}]
+              (let [[_ [x A] B] trator']
+                ;; (println "[type-of-app] trator'=" trator')
+                (if (not (type-check? def-env ctx rand A)) ;; or rand' ? (not (type-check? def-env ctx rand' A))
+                  [:ko {:msg "Cannot apply: type domain mismatch" :term [rator rand] :domain A :operand rand}]
+                  (do ;;(println "[type-of-app] subst...")
+                    ;;(println "    B = " B)
+                    ;;(println "    x = " x)
+                    ;;(println "    rand = " rand)
+                    (let [res (stx/subst B x rand)] ;; or rand' ? (stx/subst B x rand')
+                      ;;(println "   ===> " res)
+                      [:ok res [rator' rand']])))))))))))
 
 ```
 
@@ -405,8 +402,8 @@ that implicits can be erased."
             ;;     [:ko err nil]
             ;;     [:ok typ' (list* name args')]))
             ;; [:ok typ (list* name args')] ;;  no unfold (???)
-            [:ok typ (list* name args)]
-            ))))))
+            [:ok typ (list* name args)]))))))
+
 
 
 (defn type-of-args
@@ -477,7 +474,7 @@ that implicits can be erased."
 (defn unfold-implicit [def-env ctx implicit-def args]
   (let [[status, targs, args'] (type-of-implicit-args def-env ctx args)]
     (if (= status :ko)
-      [:ko targs]    
+      [:ko targs]
       (try [:ok, (apply (:implicit-fn implicit-def) def-env ctx targs), args']
            (catch Exception exc
              [:ko (merge {:implicit (:name implicit-def)
@@ -516,6 +513,4 @@ that implicits can be erased."
    (let [ty (type-of def-env ctx t)]
      (let [sort (norm/normalize def-env ctx ty)]
        (stx/sort? sort)))))
-
-
 ```

--- a/src/latte_kernel/utils.cljc
+++ b/src/latte_kernel/utils.cljc
@@ -1,5 +1,5 @@
 (ns latte-kernel.utils
- "A set of dummy utilities.")
+  "A set of dummy utilities.")
 
 (defn vconcat
   "Concatenates vectors `v1` and `v2`.
@@ -12,7 +12,7 @@
 
 (defn vcons
   "Conses element `e` in front of vector `v`.
-   (linear time)"
+  (linear time)"
   [e v]
   (vconcat [e] v))
 
@@ -37,13 +37,13 @@
 
 (defn nano-time []
   "Fetch the current time (with high precision).
-Returns 0 in clojurescript."
+  Returns 0 in clojurescript."
   #?(:clj (System/nanoTime)
      :cljs 0))
 
 (defn zip
   "Zip a sequence of even-numbered elements to a sequence of pairs,
-i.e. (zip '(x1 y2 x2 y2 ...)) = ([x1 y1] [x2 y2] ...)"
+  i.e. (zip '(x1 y2 x2 y2 ...)) = ([x1 y1] [x2 y2] ...)"
   [s]
   (if (seq s)
     (if (seq (rest s))
@@ -51,6 +51,7 @@ i.e. (zip '(x1 y2 x2 y2 ...)) = ([x1 y1] [x2 y2] ...)"
       (throw (ex-info "Cannot zip sequence with odd number of elements." {:seq s})))
     s))
 
-(defn vremove [pred v]
+(defn vremove
   "Remove all elements recognizing `pred` in vector `v`."
-  (into [] (remove pred v)))
+  [pred v]
+  (vec (remove pred v)))

--- a/test/latte_kernel/defenv_test.cljc
+++ b/test/latte_kernel/defenv_test.cljc
@@ -1,4 +1,3 @@
-
 (ns latte-kernel.defenv-test
   (:require #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :as t :refer-macros [is deftest testing]])
@@ -14,6 +13,3 @@
   (is (= (fetch-definition (register-definition empty-env (->Definition 'test [] 0 (second (parse/parse-term empty-env '(lambda [x :type] x))) nil {}))
                            'test)
          '[:ok #latte_kernel.defenv.Definition{:name test, :params [], :arity 0, :parsed-term (λ [x ✳] x), :type nil, :opts {}}])))
-
-
-

--- a/test/latte_kernel/nbe_test.cljc
+++ b/test/latte_kernel/nbe_test.cljc
@@ -1,0 +1,217 @@
+(ns latte-kernel.nbe-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :as t :refer-macros [is deftest]])
+            [latte-kernel.nbe :as nbe :refer :all]
+            [latte-kernel.syntax :as stx]))
+
+(deftest test-evaluation
+  (is (= (evaluation 'a)
+         [::nbe/var ::nbe/a]))
+
+  (is (= (evaluation '(λ [a ✳] a))
+         [::nbe/lambda '(fn [a] a)]))
+
+  (let [[kw1 [kw2 f] v] (evaluation '[(λ [a ✳] a) b])]
+    (is (= kw1 ::nbe/app))
+    (is (= kw2 ::nbe/lambda))
+    (is (= (meta f)
+           {::nbe/var-name ::nbe/a
+            ::nbe/var-type [::nbe/sort ::nbe/✳]}))
+    (is (= v [::nbe/var ::nbe/b]))
+    (is (fn? (eval f)))
+    (is (= ((eval f) v) v)))
+
+  (is (= (evaluation '[a b])
+         [::nbe/app
+           [::nbe/var ::nbe/a]
+           [::nbe/var ::nbe/b]]))
+
+  (let [[a1 [a2 [l1 f1] v1] v2] (evaluation '[[(λ [a ✳] (λ [b ✳] [a b])) c] d])
+        [f arg [l2 f2]] f1]
+    (is (= a1 a2 ::nbe/app))
+    (is (= l1 ::nbe/lambda))
+    (is (= v1 [::nbe/var ::nbe/c]))
+    (is (= v2 [::nbe/var ::nbe/d]))
+    (is (= f 'fn))
+    (is (= arg '[a]))
+    (is (= l2 ::nbe/lambda))
+    (is (fn? (eval f1)))
+    (is (= (meta f1)
+           {::nbe/var-name ::nbe/a
+            ::nbe/var-type [::nbe/sort ::nbe/✳]}))
+    (is (= (first f2) 'fn)))
+
+  (let [[a1 [a2 [a3 f1]]] (evaluation '[[[(λ [x ✳] (λ [x ✳] (λ [x ✳] x))) a] b] c])
+        [l1 [_ _ [l2 [_ _ [l3 [_ _ body]]]]]] f1]
+    (is (= a1 a2 a3 ::nbe/app))
+    (is (= l1 l2 l3 ::nbe/lambda))
+    (is (= body 'x)))
+
+  (let [[as [v1 v2] [ap [l f] [v3 v4]]] (evaluation '(::stx/ascribe z [(λ [x ✳] x) y]))]
+     (is (= as ::nbe/asc))
+     (is (= v1 v3 ::nbe/var))
+     (is (= v2 ::nbe/z))
+     (is (= v4 ::nbe/y))
+     (is (= ap ::nbe/app))
+     (is (= l ::nbe/lambda))
+     (is (= f '(fn [x] x))))
+
+  (let [[kw v] (evaluation '(Π [⇧ A] B))]
+    (is (= kw ::nbe/pi))
+    (is (= v [::nbe/var ::nbe/B]))
+    (is (= (meta v) {::nbe/var-name ::nbe/⇧, ::nbe/var-type [::nbe/var ::nbe/A]})))
+
+  (is (= (evaluation '(Π [A ✳] (Π [B ✳] (Π [⇧ (Π [⇧ A] B)] (Π [⇧ A] (Π [⇧ A] B))))))
+         [:latte-kernel.nbe/pi
+          [:latte-kernel.nbe/pi
+           [:latte-kernel.nbe/pi
+            [:latte-kernel.nbe/pi
+             [:latte-kernel.nbe/pi 'B]]]]])))
+
+(deftest test-normalisation
+  (is (= (evaluation 'a)
+         (normalisation (evaluation 'a))))
+
+  (let [[_ f1] (evaluation '(λ [y ✳] y))
+        [_ f2] (normalisation (evaluation '(λ [y ✳] y)))]
+    (is (= f1 f2))
+    (is (= (meta f1) (meta f2))))
+
+  (is (= (normalisation [::nbe/app
+                         [::nbe/lambda
+                           (with-meta '(fn [x] x)
+                             {::nbe/var-name ::nbe/x
+                              ::nbe/var-type [::nbe/sort ::nbe/✳]})]
+                         [::nbe/var 'y]])
+         [::nbe/var 'y]))
+
+  (is (= (normalisation [::nbe/app
+                         [::nbe/var 'y]
+                         [::nbe/var 'z]])
+         [::nbe/app
+           [::nbe/var 'y]
+           [::nbe/var 'z]]))
+
+  (is (= (normalisation (evaluation '[[[(λ [x ✳] (λ [x ✳] (λ [x ✳] x))) a] b] c]))
+         ;; We can see here how long the nbe-specific syntax can become
+         (normalisation [::nbe/app
+                         [::nbe/app
+                          [::nbe/app
+                           [::nbe/lambda
+                            (with-meta
+                             (list 'fn ['x]
+                              [::nbe/lambda
+                               (with-meta
+                                (list 'fn ['x]
+                                  [::nbe/lambda
+                                   (with-meta '(fn [x] x)
+                                     {::nbe/var-name ::nbe/x
+                                      ::nbe/var-type [::nbe/sort ::nbe/✳]})])
+                                {::nbe/var-name ::nbe/x
+                                 ::nbe/var-type [::nbe/sort ::nbe/✳]})])
+                             {::nbe/var-name ::nbe/x
+                              ::nbe/var-type [::nbe/sort ::nbe/✳]})]
+                           [::nbe/var ::nbe/a]]
+                          [::nbe/var ::nbe/b]]
+                         [::nbe/var ::nbe/c]])
+        [::nbe/var ::nbe/c]))
+
+  (let [[_ f] (normalisation (evaluation '[(λ [x ✳] (λ [y ✳] [x y])) a]))]
+    (is (fn? f))
+    (is (= (f [::nbe/var ::nbe/b])
+           [::nbe/app
+            [::nbe/var ::nbe/a]
+            [::nbe/var ::nbe/b]])))
+
+  (let [[_ [_ v1] [_ v2]] (normalisation (evaluation '(::stx/ascribe z [(λ [x ✳] x) y])))]
+    (is (= v1 ::nbe/z))
+    (is (= v2 ::nbe/y)))
+
+  (is (= (normalisation (evaluation '(Π [⇧ A] B)))
+         (evaluation '(Π [⇧ A] B))))
+
+  (is (= (normalisation (evaluation '(Π [A ✳] (Π [B ✳] (Π [⇧ (Π [⇧ A] B)] (Π [⇧ A] (Π [⇧ A] B)))))))
+         (evaluation '(Π [A ✳] (Π [B ✳] (Π [⇧ (Π [⇧ A] B)] (Π [⇧ A] (Π [⇧ A] B)))))))))
+
+(deftest test-quotation
+  (is (= (quotation [::nbe/var 'y])
+         'y))
+
+  (is (= (quotation [::nbe/app
+                     [::nbe/var 'y]
+                     [::nbe/var 'z]])
+         '[y z]))
+
+  (is (= (quotation [::nbe/lambda
+                 ;; The symbol used for the actual function instanciation
+                 ;; doesn't matter since we use the metadatum to convert back.
+                     (with-meta '(fn [x] x)
+                       {::nbe/var-name ::nbe/y
+                        ::nbe/var-type [::nbe/sort ::nbe/✳]})])
+         '(λ [y ✳] y)))
+
+  (is (= (quotation [::nbe/asc [::nbe/var ::nbe/z] [::nbe/var ::nbe/y]])
+         '(::stx/ascribe z y)))
+
+  (is (= (quotation [::nbe/pi
+                     (with-meta [::nbe/var ::nbe/B]
+                       {::nbe/var-name ::nbe/⇧
+                        ::nbe/var-type [::nbe/var ::nbe/A]})])
+         '(Π [⇧ A] B))))
+
+(deftest test-norm
+  (is (= (norm 'a)
+         'a))
+
+  (is (= (norm '(λ [x ✳] x))
+         '(λ [x ✳] x)))
+
+  (is (= (norm '[[(λ [x ✳] (λ [y ✳] [x y])) z] t])
+         '[z t]))
+
+  (is (= (norm '[(λ [x ✳] (λ [y ✳] [x y])) z])
+         '(λ [y ✳] [z y])))
+
+  (is (= (norm '[[[(λ [x ✳] (λ [x ✳] (λ [x ✳] x))) a] b] c])
+         'c))
+
+  (is (= (norm '[[[(λ [x ✳] (λ [y ✳] (λ [x ✳] [x y]))) a] b] c])
+         '[c b]))
+
+  (is (= (norm '(λ [x ✳] [(λ [y ✳] (λ [z ✳] [[x y] z])) a]))
+         '(λ [x ✳] (λ [z ✳] [[x a] z]))))
+
+  (is (= (norm '(Π [⇧ A] B))
+         '(Π [⇧ A] B)))
+
+  (is (= (norm '(Π [A ✳] (Π [B ✳] (Π [⇧ (Π [⇧ A] B)] (Π [⇧ A] (Π [⇧ A] B))))))
+         '(Π [A ✳] (Π [B ✳] (Π [⇧ (Π [⇧ A] B)] (Π [⇧ A] (Π [⇧ A] B))))))))
+
+(deftest test-equiv-beta-red
+  "These tests are the same as those in norm-test"
+  (is (= (norm '[(λ [x ✳] [x x]) y])
+         '[y y]))
+
+  (is (= (norm '[(λ [x ✳] x) y])
+         'y))
+
+  (is (= (norm '[[(λ [x ✳] x) y] z])
+         '[y z]))
+
+  (is (= (norm '(λ [y [(λ [x □] x) ✳]] y))
+         '(λ [y ✳] y)))
+
+  (is (= (norm '[z [(λ [x ✳] x) y]])
+         '[z y]))
+
+  (is (= (norm '(::stx/ascribe z [(λ [x ✳] x) y]))
+         '(::stx/ascribe z y)))
+
+  (is (= (norm '(::stx/ascribe [(λ [x ✳] x) y] z))
+         '(::stx/ascribe y z)))
+
+  (is (= (norm '[x y])
+         '[x y]))
+
+  (is (= (norm '(λ [y [(λ [x □] x) ✳]] [(λ [x ✳] x) y]))
+         '(λ [y ✳] y))))

--- a/test/latte_kernel/norm_test.cljc
+++ b/test/latte_kernel/norm_test.cljc
@@ -1,4 +1,3 @@
-
 (ns latte-kernel.norm-test
   (:require #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :as t :refer-macros [is deftest testing]])
@@ -12,22 +11,22 @@
 (deftest test-beta-red
   (is (= (beta-red '[(λ [x ✳] x) y])
          'y))
-  
+
   (is (= (beta-red '[[(λ [x ✳] x) y] z])
          '[y z]))
-  
+
   (is (= (beta-red '(λ [y [(λ [x □] x) ✳]] y))
          '(λ [y ✳] y)))
-  
+
   (is (= (beta-red '[z [(λ [x ✳] x) y]])
          '[z y]))
 
   (is (= (beta-red '(:latte-kernel.syntax/ascribe z [(λ [x ✳] x) y]))
          '(:latte-kernel.syntax/ascribe z y)))
-  
+
   (is (= (beta-red '(:latte-kernel.syntax/ascribe [(λ [x ✳] x) y] z))
          '(:latte-kernel.syntax/ascribe y z)))
-  
+
   (is (= (beta-red '[x y])
          '[x y])))
 
@@ -36,12 +35,12 @@
                           '[[x y] [z x]]
                           '((λ [t ✳] t) t1 [t2 t3]))
          '[[(λ [t ✳] t) t1] [[t2 t3] (λ [t ✳] t)]]))
-  
+
   (is (= (instantiate-def '[[x ✳] [y ✳] [z ✳] [t ✳]]
                           '[[x y] [z t]]
                           '((λ [t ✳] t) t1 [t2 t3]))
          '(λ [t' ✳] [[(λ [t ✳] t) t1] [[t2 t3] t']])))
-  
+
   (is (= (instantiate-def '[[x ✳] [y ✳] [z ✳]]
                           '[[x y] z]
                           '())
@@ -66,7 +65,7 @@
                           []
                           '(test [a b] c [t (λ [t] t)]))
          '[(test [a b] c [t (λ [t] t)]) false]))
- 
+
   (is (= (delta-reduction (defenv/mkenv {'test (defenv/map->Axiom
                                                  '{:arity 3
                                                    :tag :axiom
@@ -88,7 +87,7 @@
 (deftest test-delta-step
   (is (= (delta-step {} [] 'x)
          '[x 0]))
-      
+
   (is (= (delta-step (defenv/mkenv {'test (defenv/map->Definition
                                             '{:arity 1
                                               :tag :definition
@@ -123,9 +122,6 @@
   (is (= (normalize '(λ [y [(λ [x □] x) ✳]] [(λ [x ✳] x) y]))
          '(λ [y ✳] y))))
 
-
 (deftest test-beta-eq?
-  (is (= (beta-eq? '(λ [z ✳] z)
-                   '(λ [y [(λ [x □] x) ✳]] [(λ [x ✳] x) y]))
-         true)))
-
+  (is (beta-eq? '(λ [z ✳] z)
+                '(λ [y [(λ [x □] x) ✳]] [(λ [x ✳] x) y]))))

--- a/test/latte_kernel/presyntax_test.cljc
+++ b/test/latte_kernel/presyntax_test.cljc
@@ -1,4 +1,3 @@
-
 (ns latte-kernel.presyntax-test
   (:require #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :as t :refer-macros [is deftest testing]])
@@ -8,7 +7,6 @@
 (deftest test-reserved-symbols
   (is (= (reserved-symbol? 'a) false))
   (is (= (reserved-symbol? 'λ) true)))
-
 
 (deftest test-kind
   (is (= (kind? '□) true))

--- a/test/latte_kernel/proof_test.cljc
+++ b/test/latte_kernel/proof_test.cljc
@@ -1,4 +1,3 @@
-
 (ns latte-kernel.proof-test
   (:require #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :as t :refer-macros [is deftest testing]])
@@ -24,7 +23,7 @@
 
 (def vdeps3 (let [[_ [_ _ vdeps3]] (elab-declare defenv/empty-env ctx2 vdeps2 {}
                                            'f (second (parse/parse-term defenv/empty-env '(==> A B))) {})]
-            vdeps3))
+             vdeps3))
 
 (def ctx4 (let [[_ [_ ctx4]] (elab-declare defenv/empty-env ctx3 vdeps3 {} 'x 'A {})]
             ctx4))
@@ -34,25 +33,25 @@
 
 (deftest test-elab-declare
   ;; Step 0:
-  ;; local-defs={}   ctx=[]    var-deps=[]    def-uses={} 
-  
+  ;; local-defs={}   ctx=[]    var-deps=[]    def-uses={}
+
   (is (= (elab-declare defenv/empty-env [] [] {} 'A '✳ {})
          '[:ok [[{} {}] ([A ✳]) ([A #{}]) {}]]))
 
   ;; Step 1: [:declare A *]
   ;; local-defs={}   ctx=[[A *]]   var-deps=[[A #{}]]    def-uses={}
-  
+
   (is (= ctx1 '([A ✳])))
 
   (is (= vdeps1 '([A #{}])))
-  
+
   ;; Step 2: [:declare B *]
-  ;; local-defs={}   ctx=[[B *] [A *]]   var-deps=[[B #{}] [A #{}]]    def-uses={} 
+  ;; local-defs={}   ctx=[[B *] [A *]]   var-deps=[[B #{}] [A #{}]]    def-uses={}
   (is (= ctx2 '([B ✳] [A ✳])))
   (is (= vdeps2 '([B #{}] [A #{}])))
-  
+
   ;; Step 3: [:declare f (==> A B)]
-  ;; local-defs={}   ctx=[[f (==> A B)] [B *] [A *]]   var-deps=[[f #{}][B #{}] [A #{}]]  def-uses={} 
+  ;; local-defs={}   ctx=[[f (==> A B)] [B *] [A *]]   var-deps=[[f #{}][B #{}] [A #{}]]  def-uses={}
   (is (= ctx3 '([f (Π [⇧ A] B)] [B ✳] [A ✳])))
   (is (= vdeps3 '([f #{}] [B #{}] [A #{}])))
 
@@ -69,9 +68,8 @@
   (is (= (-> vdeps4
              (update-var-deps '<a> 'f)
              (update-var-deps '<a> (second (parse/parse-term defenv/empty-env '(==> A B)))))
-         '[[x #{<a>}] [f #{<a>}] [B #{<a>}] [A #{<a>}]]))
+         '[[x #{<a>}] [f #{<a>}] [B #{<a>}] [A #{<a>}]])))
 
-  )
 
 (let [state5 (second (elab-have defenv/empty-env ctx4 vdeps4 {} '<a> (second (parse/parse-term defenv/empty-env '(==> A B))) 'f {}))
       [def-env5 ctx5 vdeps5 dfuses5] state5]
@@ -90,7 +88,7 @@
 (deftest test-ref-uses-in-term
   (is (= (ref-uses-in-term (:parsed-term (second (defenv/fetch-definition def-env6 '<a>))))
          #{}))
-  
+
   (is (= (ref-uses-in-term (:parsed-term (second (defenv/fetch-definition def-env6 '<b>))))
          '#{<a>})))
 
@@ -103,20 +101,20 @@
   ;; local-defs={<a>:=f::(==> A B)}
   ;; ctx=[[x A] [f (==> A B)] [B *] [A *]]
   ;; var-deps=[[x #{}][f #{<a>}][B #{<a>}] [A #{<a>}]]  def-uses={<a> #{}}
-  
+
   (is (= ctx5 ctx4))
 
   (is (defenv/registered-definition? def-env5 '<a>))
 
   (is (= (second(defenv/fetch-definition def-env5 '<a> true))
          '#latte_kernel.defenv.Definition{:name <a>, :params [], :arity 0, :parsed-term f, :type (Π [⇧ A] B), :opts {}}))
-  
+
   (is (= vdeps5
          '[[x #{<a>}] [f #{<a>}] [B #{<a>}] [A #{<a>}]]))
 
   (is (= dfuses5
          '{<a> #{}}))
-  
+
   ;; Step 6 : [:have <b> B (<a> x)]
   ;; local-defs={<a>:=f::(==> A B)
   ;;             <b>:=(<a> x)::B}
@@ -134,9 +132,8 @@
          '[[x #{<a> <b>}] [f #{<a> <b>}] [B #{<a> <b>}] [A #{<a> <b>}]]))
 
   (is (= dfuses6
-         '{<a> #{<b>}, <b> #{}}))
+         '{<a> #{<b>}, <b> #{}})))
 
-  )
 
 
 (deftest test-abstract-local-defs
@@ -184,10 +181,10 @@
   ;; var-deps=[[f #{<a>}][B #{<a>,<b>}] [A #{<a>}]]  def-uses={<a> #{<b>}, <b> #{}}
   (is (= ctx7
          '([f (Π [⇧ A] B)] [B ✳] [A ✳])))
-  
+
   (is (= (second (defenv/fetch-definition def-env7 '<a> true))
          '#latte_kernel.defenv.Definition{:name <a>, :params [[x A]], :arity 1, :parsed-term f, :type (Π [⇧ A] B), :opts {}}))
- 
+
   (is (= (second (defenv/fetch-definition def-env7 '<b> true))
          '#latte_kernel.defenv.Definition{:name <b>, :params [[x A]], :arity 1, :parsed-term [(<a> x) x], :type B, :opts {}}))
 
@@ -205,10 +202,10 @@
   ;; var-deps=[[B #{<a>,<b>}] [A #{<a>}]]  def-uses={<a> #{<b>}, <b> #{}}
   (is (= ctx8
          '([B ✳] [A ✳])))
-  
+
   (is (= (second (defenv/fetch-definition def-env8 '<a> true))
          '#latte_kernel.defenv.Definition{:name <a>, :params [[f (Π [⇧ A] B)] [x A]], :arity 2, :parsed-term f, :type (Π [⇧ A] B), :opts {}}))
- 
+
   (is (= (second (defenv/fetch-definition def-env8 '<b> true))
          '#latte_kernel.defenv.Definition{:name <b>, :params [[f (Π [⇧ A] B)] [x A]], :arity 2, :parsed-term [(<a> f x) x], :type B, :opts {}}))
 
@@ -226,10 +223,10 @@
   ;; var-deps=[[A #{<a>}]]  def-uses={<a> #{<b>}, <b> #{}}
   (is (= ctx9
          '([A ✳])))
-  
+
   (is (= (second (defenv/fetch-definition def-env9 '<a> true))
          '#latte_kernel.defenv.Definition{:name <a>, :params [[B ✳] [f (Π [⇧ A] B)] [x A]], :arity 3, :parsed-term f, :type (Π [⇧ A] B), :opts {}}))
- 
+
   (is (= (second (defenv/fetch-definition def-env9 '<b> true))
          '#latte_kernel.defenv.Definition{:name <b>, :params [[B ✳] [f (Π [⇧ A] B)] [x A]], :arity 3, :parsed-term [(<a> B f x) x], :type B, :opts {}}))
 
@@ -246,10 +243,10 @@
   ;; var-deps=[[A #{<a>}]]  def-uses={<a> #{<b>}, <b> #{}}
   (is (= ctx10
          '()))
-  
+
   (is (= (second (defenv/fetch-definition def-env10 '<a> true))
          '#latte_kernel.defenv.Definition{:name <a>, :params [[A ✳] [B ✳] [f (Π [⇧ A] B)] [x A]], :arity 4, :parsed-term f, :type (Π [⇧ A] B), :opts {}}))
- 
+
   (is (= (second (defenv/fetch-definition def-env10 '<b> true))
          '#latte_kernel.defenv.Definition{:name <b>, :params [[A ✳] [B ✳] [f (Π [⇧ A] B)] [x A]], :arity 4, :parsed-term [(<a> A B f x) x], :type B, :opts {}}))
 
@@ -257,16 +254,15 @@
          '()))
 
   (is (= dfuses10
-         '{<a> #{<b>}, <b> #{}}))
-  
-  )
+         '{<a> #{<b>}, <b> #{}})))
+
 
 
 (deftest test-elab-qed
 
   ;; Step 11 :
   ;; [:qed <a> (forall [A B *] (==> (==> A B) (==> A B)))]
-  
+
   (is (= (elab-qed def-env10 ctx10 '(<a>) {})
          '[:ok [[{} {<a> #latte_kernel.defenv.Definition{:name <a>, :params [[A ✳] [B ✳] [f (Π [⇧ A] B)] [x A]], :arity 4, :parsed-term f, :type (Π [⇧ A] B), :opts {}}, <b> #latte_kernel.defenv.Definition{:name <b>, :params [[A ✳] [B ✳] [f (Π [⇧ A] B)] [x A]], :arity 4, :parsed-term [(<a> A B f x) x], :type B, :opts {}}}] (<a>) (Π [A ✳] (Π [B ✳] (Π [f (Π [⇧ A] B)] (Π [x A] (Π [⇧ A] B)))))]])))
 
@@ -295,7 +291,7 @@
                            [:have <a> (==> A B) f {:line 2}]
                            [:have <b> B (<a> x) {:line 3}]]
                           [:qed <a> {:line 4}]])
-         
+
          '([:declare A :type {:line 1}]
            [:declare B :type {:line 1}]
            [:declare f (==> A B) {:line 1}]
@@ -317,7 +313,7 @@
                            [:have <a> (==> A B) f {:line 2}]
                            [:have <b> B (<a> x) {:line 3}]]
                           [:qed <a> {:line 4}]])
-         
+
          '([:declare A :type {:line 1}]
            [:declare B :type {:line 1}]
            [:declare f (==> A B) {:line 1}]
@@ -328,9 +324,8 @@
            [:discharge f {:line 1}]
            [:discharge B {:line 1}]
            [:discharge A {:line 1}]
-           [:qed <a> {:line 4}])))
+           [:qed <a> {:line 4}]))))
 
-  )
 
 (deftest test-proof
   (is (= (elab-proof defenv/empty-env []
@@ -343,7 +338,7 @@
                                       [:have <b> B (<a> x) {:line 3}]]
                                      [:qed <a> {:line 4}]]))
          '[:ok [[{} {<a> #latte_kernel.defenv.Definition{:name <a>, :params [[A ✳] [B ✳] [f (Π [⇧ A] B)] [x A]], :arity 4, :parsed-term f, :type (Π [⇧ A] B), :opts {}}, <b> #latte_kernel.defenv.Definition{:name <b>, :params [[A ✳] [B ✳] [f (Π [⇧ A] B)] [x A]], :arity 4, :parsed-term [(<a> A B f x) x], :type B, :opts {}}}] (<a>) (Π [A ✳] (Π [B ✳] (Π [f (Π [⇧ A] B)] (Π [x A] (Π [⇧ A] B)))))]]))
-  
+
   (is (= (check-proof defenv/empty-env [] 'my-thm
                       (second (parse/parse-term defenv/empty-env '(forall [A B :type] (==> (==> A B) (==> A A B)))))
                       '[[:assume {:line 1}
@@ -355,8 +350,3 @@
                          [:have <b> B (<a> x) {:line 3}]]
                         [:qed <a> {:line 4}]])
          '[:ok [(<a>) (Π [A ✳] (Π [B ✳] (Π [f (Π [⇧ A] B)] (Π [x A] (Π [⇧ A] B)))))]])))
-
-
-
-
-

--- a/test/latte_kernel/typing_test.cljc
+++ b/test/latte_kernel/typing_test.cljc
@@ -1,4 +1,3 @@
-
 (ns latte-kernel.typing-test
   (:require #?@(:clj [[clojure.test :refer :all]
                       [matcher-combinators.test]]

--- a/test/latte_kernel/unparser_test.cljc
+++ b/test/latte_kernel/unparser_test.cljc
@@ -1,4 +1,3 @@
-
 (ns latte-kernel.unparser-test
   (:require #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :as t :refer-macros [is deftest testing]])
@@ -13,11 +12,3 @@
 
   (is (= (prod-impl-unparser '(Π [⇧ A] (==> B C D)))
          '[(==> A B C D) true])))
-
-
-
-
-
-
-
-


### PR DESCRIPTION
In norm.cljc, we can choose to use either the old beta-step, the new nbe, or both and alpha-compare the results.
All tests pass obviously, but the time difference between the three options is negligible