### PR TITLE
Bugfix in typing?

### DIFF
--- a/src/latte_kernel/typing.cljc
+++ b/src/latte_kernel/typing.cljc
@@ -221,7 +221,7 @@
   (let [[status err A'] (type-of-term def-env ctx A)]
     (if (= status :ko)
       [:ko {:msg "Cannot calculate domain type of abstraction."
-            :term (list 'λ [x A] t) :from err} nil])
+            :term (list 'λ [x A] t) :from err} nil]
     (let [ctx' (ctx-put ctx x A) ;; or A' ? (ctx-put ctx x A')
           [status B t'] (type-of-term def-env ctx' t)]
       (if (= status :ko)
@@ -238,7 +238,7 @@
                     :term (list 'λ [x A] t')
                     :codomain B
                     :type sort}]
-              [:ok tprod (list 'λ [x A'] t')])))))))
+              [:ok tprod (list 'λ [x A'] t')]))))))))
 
 
 ;;{

--- a/src/latte_kernel/typing.cljc
+++ b/src/latte_kernel/typing.cljc
@@ -222,23 +222,23 @@
     (if (= status :ko)
       [:ko {:msg "Cannot calculate domain type of abstraction."
             :term (list 'λ [x A] t) :from err} nil]
-    (let [ctx' (ctx-put ctx x A) ;; or A' ? (ctx-put ctx x A')
-          [status B t'] (type-of-term def-env ctx' t)]
-      (if (= status :ko)
-        [:ko {:msg "Cannot calculate codomain type of abstraction."
-              :term (list 'λ [x A] t) :from B} nil]
-        (let [tprod (list 'Π [x A] B) ;; or A' ? (list 'Π [x A'] B)
-              [status sort tprod'] (type-of-term def-env ctx tprod)]
-          (if (= status :ko)
-            [:ko {:msg "Not a valid codomain type in abstraction (cannot calculate super-type)."
-                  :term (list 'λ [x A] t')
-                  :codomain B :from sort} nil]
-            (if (not (stx/sort? (norm/normalize def-env ctx sort)))
-              [:ko {:msg "Not a valid codomain type in abstraction (super-type not a sort)."
+      (let [ctx' (ctx-put ctx x A) ;; or A' ? (ctx-put ctx x A')
+            [status B t'] (type-of-term def-env ctx' t)]
+        (if (= status :ko)
+          [:ko {:msg "Cannot calculate codomain type of abstraction."
+                :term (list 'λ [x A] t) :from B} nil]
+          (let [tprod (list 'Π [x A] B) ;; or A' ? (list 'Π [x A'] B)
+                [status sort tprod'] (type-of-term def-env ctx tprod)]
+            (if (= status :ko)
+              [:ko {:msg "Not a valid codomain type in abstraction (cannot calculate super-type)."
                     :term (list 'λ [x A] t')
-                    :codomain B
-                    :type sort}]
-              [:ok tprod (list 'λ [x A'] t')]))))))))
+                    :codomain B :from sort} nil]
+              (if (not (stx/sort? (norm/normalize def-env ctx sort)))
+                [:ko {:msg "Not a valid codomain type in abstraction (super-type not a sort)."
+                      :term (list 'λ [x A] t')
+                      :codomain B
+                      :type sort}]
+                [:ok tprod (list 'λ [x A'] t')]))))))))
 
 
 ;;{

--- a/src/latte_kernel/typing.cljc.md
+++ b/src/latte_kernel/typing.cljc.md
@@ -238,7 +238,7 @@
   (let [[status err A'] (type-of-term def-env ctx A)]
     (if (= status :ko)
       [:ko {:msg "Cannot calculate domain type of abstraction."
-            :term (list 'λ [x A] t) :from err} nil])
+            :term (list 'λ [x A] t) :from err} nil]
     (let [ctx' (ctx-put ctx x A) ;; or A' ? (ctx-put ctx x A')
           [status B t'] (type-of-term def-env ctx' t)]
       (if (= status :ko)
@@ -255,7 +255,7 @@
                     :term (list 'λ [x A] t')
                     :codomain B
                     :type sort}]
-              [:ok tprod (list 'λ [x A'] t')])))))))
+              [:ok tprod (list 'λ [x A'] t')]))))))))
 
 
 ```

--- a/src/latte_kernel/typing.cljc.md
+++ b/src/latte_kernel/typing.cljc.md
@@ -239,23 +239,23 @@
     (if (= status :ko)
       [:ko {:msg "Cannot calculate domain type of abstraction."
             :term (list 'λ [x A] t) :from err} nil]
-    (let [ctx' (ctx-put ctx x A) ;; or A' ? (ctx-put ctx x A')
-          [status B t'] (type-of-term def-env ctx' t)]
-      (if (= status :ko)
-        [:ko {:msg "Cannot calculate codomain type of abstraction."
-              :term (list 'λ [x A] t) :from B} nil]
-        (let [tprod (list 'Π [x A] B) ;; or A' ? (list 'Π [x A'] B)
-              [status sort tprod'] (type-of-term def-env ctx tprod)]
-          (if (= status :ko)
-            [:ko {:msg "Not a valid codomain type in abstraction (cannot calculate super-type)."
-                  :term (list 'λ [x A] t')
-                  :codomain B :from sort} nil]
-            (if (not (stx/sort? (norm/normalize def-env ctx sort)))
-              [:ko {:msg "Not a valid codomain type in abstraction (super-type not a sort)."
+      (let [ctx' (ctx-put ctx x A) ;; or A' ? (ctx-put ctx x A')
+            [status B t'] (type-of-term def-env ctx' t)]
+        (if (= status :ko)
+          [:ko {:msg "Cannot calculate codomain type of abstraction."
+                :term (list 'λ [x A] t) :from B} nil]
+          (let [tprod (list 'Π [x A] B) ;; or A' ? (list 'Π [x A'] B)
+                [status sort tprod'] (type-of-term def-env ctx tprod)]
+            (if (= status :ko)
+              [:ko {:msg "Not a valid codomain type in abstraction (cannot calculate super-type)."
                     :term (list 'λ [x A] t')
-                    :codomain B
-                    :type sort}]
-              [:ok tprod (list 'λ [x A'] t')]))))))))
+                    :codomain B :from sort} nil]
+              (if (not (stx/sort? (norm/normalize def-env ctx sort)))
+                [:ko {:msg "Not a valid codomain type in abstraction (super-type not a sort)."
+                      :term (list 'λ [x A] t')
+                      :codomain B
+                      :type sort}]
+                [:ok tprod (list 'λ [x A'] t')]))))))))
 
 
 ```

--- a/test/latte_kernel/typing_test.cljc
+++ b/test/latte_kernel/typing_test.cljc
@@ -69,11 +69,9 @@
          '[:ok (Π [x ✳] ✳) (λ [x ✳] x)]))
 
   (is (= (type-of-term defenv/empty-env '[[y bool]] '(λ [x bool] x))
-         '[:ko {:msg "Cannot calculate codomain type of abstraction.",
+         '[:ko {:msg "Cannot calculate domain type of abstraction.",
                 :term (λ [x bool] x),
-                :from {:msg "Cannot calculate type of variable.",
-                       :term x,
-                       :from {:msg "No such variable in type context", :term bool}}}
+                :from {:msg "No such variable in type context", :term bool}}
            nil]))
 
   (is (= (type-of-term defenv/empty-env '[[y ✳] [z y]] '(λ [x z] x))


### PR DESCRIPTION
This really looks like a bug, since having a single-branch `if` and discarding the result doesn't look like intended behaviour, but that behaviour is validated by a single test.
Changing that single test doesn't break anything, and the entire library still works with it.
See the first commit (https://github.com/latte-central/latte-kernel/commit/ffe5d1075e512437d86947823f1ebb368f674646) for a simpler view of what changed.